### PR TITLE
Remove stop_ioloop_on_close argument for newer pika

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+<h1>Changelog</h1>
+<h2>1.7.1</h2>
+Remove the `stop_ioloop_on_close` argument since this is no longer in `pika>=1.0.0`.
+Since removing this argument will change behaviour on version still using `pika<1.0.0`
+make sure we require at least `pika>1.0.0` in setup.py so people installing this new
+version will not have changed behaviour.

--- a/amqpconsumer/events.py
+++ b/amqpconsumer/events.py
@@ -85,8 +85,7 @@ class EventConsumer(object):
         """
         logger.debug('Connecting to %s', self._url)
         return pika.SelectConnection(pika.URLParameters(self._url),
-                                     self.on_connection_open,
-                                     stop_ioloop_on_close=False)
+                                     self.on_connection_open)
 
     def on_connection_open(self, _):
         """Called by pika once the connection to RabbitMQ has been established.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='amqpconsumer',
-    version='1.7',
+    version='1.7.1',
     description='AMQP event listener',
     url='https://github.com/ByteInternet/amqpconsumer',
     author='Byte B.V.',
@@ -25,5 +25,5 @@ setup(
     ],
     keywords='amqp events consumer listener rabbitmq',
     packages=['amqpconsumer'],
-    install_requires=['pika>=0.9.8']
+    install_requires=['pika>=1.0.0']
 )


### PR DESCRIPTION
Remove the stop_ioloop_on_close since this is no longer available for
newer pika version. Update the the package requirement accordingly,
since having a version of pika below 1.0.0 will change behaviour.