### PR TITLE
Fix on_exchange_declareok callback

### DIFF
--- a/amqpconsumer/events.py
+++ b/amqpconsumer/events.py
@@ -167,9 +167,9 @@ class EventConsumer(object):
         When completed, the on_exchange_declareok method will be invoked by pika.
         """
         logger.debug('Declaring exchange %s', self._exchange)
-        self._channel.exchange_declare(self.on_exchange_declareok,
-                                       self._exchange,
-                                       self._exchange_type,
+        self._channel.exchange_declare(exchange=self._exchange,
+                                       exchange_type=self._exchange_type,
+                                       callback=self.on_exchange_declareok,
                                        durable=True)
 
     def on_exchange_declareok(self, _):


### PR DESCRIPTION
Newer pika versions have changed the order of the arguments in
`exchange_declare`. So now when trying to set up an exchange we pass in
the wrong parameters. To prevent this from happening again I've made
them kwargs (also changed order a little to match the method signature)

See method signature for `exchange_declare` here:
https://pika.readthedocs.io/en/stable/_modules/pika/channel.html

Already fixed this once for `queue_declare` as well here:
https://github.com/ByteInternet/amqpconsumer/pull/12